### PR TITLE
Tweak PopularPosts gadget.

### DIFF
--- a/src/_defaultmarkups/gadgets/PopularPosts.scss
+++ b/src/_defaultmarkups/gadgets/PopularPosts.scss
@@ -69,7 +69,6 @@
   margin-top: 0;
   margin-bottom: .25rem;
   padding-left: 0;
-  color: #777;
   font-size: .875rem;
   list-style: none;
 
@@ -88,9 +87,11 @@
   }
 }
 
-//= Link
+//= Text
 
-// .popular-post-meta-link {}
+.popular-post-meta-text {
+  color: #777;
+}
 
 //
 // Snippet

--- a/src/_defaultmarkups/gadgets/PopularPosts.xml
+++ b/src/_defaultmarkups/gadgets/PopularPosts.xml
@@ -61,7 +61,7 @@
             <ul class='popular-post-meta'>
               <b:comment>=== Date (published) ===</b:comment>
               <li class='popular-post-meta-item'>
-                <time expr:datetime='data:post.date.iso8601' expr:title='data:post.date.iso8601'>
+                <time class='popular-post-meta-text' expr:datetime='data:post.date.iso8601' expr:title='data:post.date.iso8601'>
                   <b:eval expr='format(data:post.date, "MMM dd, YYYY")'/>
                 </time>
               </li>


### PR DESCRIPTION
- Remove unused `.popular-post-meta-link`.
- Add `.popular-post-meta-text` and remove color on `.popular-post-meta`.